### PR TITLE
Pass on lighting related parameters; allow specification of face and vertex normals epsilons

### DIFF
--- a/mesh.js
+++ b/mesh.js
@@ -235,6 +235,21 @@ proto.update = function(params) {
   if('opacity' in params) {
     this.opacity = params.opacity
   }
+  if('ambient' in params) {
+    this.ambientLight  = params.ambient
+  }
+  if('diffuse' in params) {
+    this.diffuseLight = params.diffuse
+  }
+  if('specular' in params) {
+    this.specularLight = params.specular
+  }
+  if('roughness' in params) {
+    this.roughness = params.roughness
+  }
+  if('fresnel' in params) {
+    this.fresnel = params.fresnel
+  }
 
   if(params.texture) {
     this.texture.dispose()

--- a/mesh.js
+++ b/mesh.js
@@ -1,5 +1,8 @@
 'use strict'
 
+var DEFAULT_VERTEX_NORMALS_EPSILON = 1e-6; // may be too large if triangles are very small
+var DEFAULT_FACE_NORMALS_EPSILON = 1e-6;
+
 var createShader  = require('gl-shader')
 var createBuffer  = require('gl-buffer')
 var createVAO     = require('gl-vao')
@@ -293,11 +296,13 @@ proto.update = function(params) {
   //Compute normals
   var vertexNormals = params.vertexNormals
   var cellNormals   = params.cellNormals
+  var vertexNormalsEpsilon = params.vertexNormalsEpsilon === void(0) ? DEFAULT_VERTEX_NORMALS_EPSILON : params.vertexNormalsEpsilon
+  var faceNormalsEpsilon = params.faceNormalsEpsilon === void(0) ? DEFAULT_FACE_NORMALS_EPSILON : params.vertexNormalsEpsilon
   if(params.useFacetNormals && !cellNormals) {
-    cellNormals = normals.faceNormals(cells, positions)
+    cellNormals = normals.faceNormals(cells, positions, faceNormalsEpsilon)
   }
   if(!cellNormals && !vertexNormals) {
-    vertexNormals = normals.vertexNormals(cells, positions)
+    vertexNormals = normals.vertexNormals(cells, positions, vertexNormalsEpsilon)
   }
 
   //Compute colors

--- a/mesh.js
+++ b/mesh.js
@@ -297,7 +297,7 @@ proto.update = function(params) {
   var vertexNormals = params.vertexNormals
   var cellNormals   = params.cellNormals
   var vertexNormalsEpsilon = params.vertexNormalsEpsilon === void(0) ? DEFAULT_VERTEX_NORMALS_EPSILON : params.vertexNormalsEpsilon
-  var faceNormalsEpsilon = params.faceNormalsEpsilon === void(0) ? DEFAULT_FACE_NORMALS_EPSILON : params.vertexNormalsEpsilon
+  var faceNormalsEpsilon = params.faceNormalsEpsilon === void(0) ? DEFAULT_FACE_NORMALS_EPSILON : params.faceNormalsEpsilon
   if(params.useFacetNormals && !cellNormals) {
     cellNormals = normals.faceNormals(cells, positions, faceNormalsEpsilon)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-mesh3d",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "3D mesh drawing",
   "main": "mesh.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "glsl-specular-cook-torrance": "^2.0.1",
     "glslify": "^2.1.2",
     "ndarray": "^1.0.15",
-    "normals": "^1.0.0",
+    "normals": "^1.0.1",
     "polytope-closest-point": "^1.0.0",
     "simplicial-complex-contour": "^1.0.0",
     "typedarray-pool": "^1.1.0"


### PR DESCRIPTION
Helps fix https://github.com/plotly/plotly.js/issues/552 (see visual effects)