### PR TITLE
Refactor face normals detection

### DIFF
--- a/example/flat.js
+++ b/example/flat.js
@@ -14,6 +14,10 @@ document.body.appendChild(canvas)
 window.addEventListener('resize', require('canvas-fit')(canvas))
 var gl = canvas.getContext('webgl')
 
+var ext = (
+  gl.getExtension('OES_standard_derivatives')
+)
+
 var bounds = getBounds(bunny.positions)
 var camera = createCamera(canvas, {
   eye:    [0,0,50],
@@ -26,7 +30,8 @@ var mesh = createMesh(gl, {
   cells:      bunny.cells,
   positions:  bunny.positions,
   meshColor:  [1, 0, 0],
-  useFacetNormals: true
+  useFacetNormals: true,
+  specular: 5.
 })
 var select = createSelect(gl, [canvas.width, canvas.height])
 var axes = createAxes(gl, { bounds: bounds })

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -1,6 +1,6 @@
 #extension GL_OES_standard_derivatives : enable
 
-precision mediump float;
+precision highp float;
 
 #pragma glslify: cookTorrance = require(glsl-specular-cook-torrance)
 #pragma glslify: faceNormal = require('glsl-face-normal')

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -1,6 +1,9 @@
+#extension GL_OES_standard_derivatives : enable
+
 precision mediump float;
 
 #pragma glslify: cookTorrance = require(glsl-specular-cook-torrance)
+#pragma glslify: faceNormal = require('glsl-face-normal')
 
 uniform vec3 clipBounds[2];
 uniform float roughness
@@ -14,12 +17,13 @@ uniform sampler2D texture;
 varying vec3 f_normal
            , f_lightDirection
            , f_eyeDirection
-           , f_data;
+           , f_data
+           , f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 
 void main() {
-  if(any(lessThan(f_data, clipBounds[0])) || 
+  if(any(lessThan(f_data, clipBounds[0])) ||
      any(greaterThan(f_data, clipBounds[1]))) {
     discard;
   }
@@ -27,9 +31,11 @@ void main() {
   vec3 N = normalize(f_normal);
   vec3 L = normalize(f_lightDirection);
   vec3 V = normalize(f_eyeDirection);
-  
-  if(!gl_FrontFacing) {
-    N = -N;
+
+  vec3 normal = faceNormal(f_position);
+
+  if (dot(N, normal) < 0.0) {
+      N = -N;
   }
 
   float specular = cookTorrance(L, V, N, roughness, fresnel);

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -33,7 +33,7 @@ void main() {
 
   vec3 normal = faceNormal(f_data);
 
-  if (dot(N, normal) < 0.0) {
+  if (dot(N, normal) >= 0.0) {
       N = -N;
   }
 

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -17,8 +17,7 @@ uniform sampler2D texture;
 varying vec3 f_normal
            , f_lightDirection
            , f_eyeDirection
-           , f_data
-           , f_position;
+           , f_data;
 varying vec4 f_color;
 varying vec2 f_uv;
 
@@ -32,7 +31,7 @@ void main() {
   vec3 L = normalize(f_lightDirection);
   vec3 V = normalize(f_eyeDirection);
 
-  vec3 normal = faceNormal(f_position);
+  vec3 normal = faceNormal(f_data);
 
   if (dot(N, normal) < 0.0) {
       N = -N;

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -33,7 +33,9 @@ void main() {
 
   vec3 normal = faceNormal(f_data);
 
-  if (dot(N, normal) >= 0.0) {
+  if (
+    dot(N, normal) < 0.0
+    ) {
       N = -N;
   }
 

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -13,8 +13,7 @@ uniform vec3 eyePosition
 varying vec3 f_normal
            , f_lightDirection
            , f_eyeDirection
-           , f_data
-           , f_position;
+           , f_data;
 varying vec4 f_color;
 varying vec2 f_uv;
 
@@ -25,7 +24,6 @@ void main() {
   f_color          = color;
   f_normal         = normal;
   f_data           = position;
-  f_position       = -t_position.xyz;
   f_eyeDirection   = eyePosition   - position;
   f_lightDirection = lightPosition - position;
   f_uv             = uv;

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 attribute vec3 position, normal;
 attribute vec4 color;

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -13,7 +13,8 @@ uniform vec3 eyePosition
 varying vec3 f_normal
            , f_lightDirection
            , f_eyeDirection
-           , f_data;
+           , f_data
+           , f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 
@@ -24,6 +25,7 @@ void main() {
   f_color          = color;
   f_normal         = normal;
   f_data           = position;
+  f_position       = -t_position.xyz;
   f_eyeDirection   = eyePosition   - position;
   f_lightDirection = lightPosition - position;
   f_uv             = uv;

--- a/mesh.js
+++ b/mesh.js
@@ -30,6 +30,7 @@ var identityMatrix = [
   0,0,1,0,
   0,0,0,1]
 
+
 function SimplicialMesh(gl
   , texture
   , triShader

--- a/mesh.js
+++ b/mesh.js
@@ -878,6 +878,11 @@ function createSimplicialMesh(gl, params) {
     gl = params.gl;
   }
 
+  //enable derivatives for face normals
+  var ext = gl.getExtension('OES_standard_derivatives')
+  if (!ext)
+    throw new Error('derivatives not supported')
+
   var triShader       = createMeshShader(gl)
   var lineShader      = createWireShader(gl)
   var pointShader     = createPointShader(gl)

--- a/mesh.js
+++ b/mesh.js
@@ -879,7 +879,7 @@ function createSimplicialMesh(gl, params) {
   }
 
   //enable derivatives for face normals
-  var ext = gl.getExtension('OES_standard_derivatives')
+  var ext = gl.getExtension('OES_standard_derivatives') || gl.getExtension('MOZ_OES_standard_derivatives') || gl.getExtension('WEBKIT_OES_standard_derivatives')
   if (!ext)
     throw new Error('derivatives not supported')
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gl-shader": "^4.0.5",
     "gl-texture2d": "^2.0.8",
     "gl-vao": "^1.1.3",
+    "glsl-face-normal": "^1.0.2",
     "glsl-specular-cook-torrance": "^2.0.1",
     "glslify": "^2.1.2",
     "ndarray": "^1.0.15",


### PR DESCRIPTION
Because we should not use `gl_FrontFacing` - it is not supported well across devices.
Related to http://stackoverflow.com/questions/24375171/is-there-a-reliable-alternative-to-gl-frontfacing-in-a-fragment-shader.
Should fix https://github.com/plotly/plotly.js/issues/1368