### PR TITLE
Fix mouse event on high resolution screens

### DIFF
--- a/mesh.js
+++ b/mesh.js
@@ -764,7 +764,7 @@ proto.pick = function(pickData) {
 
   var data = closestPoint(
     simplex,
-    [pickData.coord[0], this._resolution[1]-pickData.coord[1]],
+    [window.devicePixelRatio * pickData.coord[0], this._resolution[1] - window.devicePixelRatio * pickData.coord[1]],
     this._model,
     this._view,
     this._projection,


### PR DESCRIPTION
It doesn't handle cases for high resolution screens such as Retina,

You can test it by running tests in plotly.js:

npm run test-jasmine -- gl_plot_interact