### PR TITLE
Options to enable opacityscale

### DIFF
--- a/lib/contour-fragment.glsl
+++ b/lib/contour-fragment.glsl
@@ -3,5 +3,5 @@ precision mediump float;
 uniform vec3 contourColor;
 
 void main() {
-  gl_FragColor = vec4(contourColor,1);
+  gl_FragColor = vec4(contourColor, 1.0);
 }

--- a/lib/pick-point-vertex.glsl
+++ b/lib/pick-point-vertex.glsl
@@ -15,7 +15,7 @@ varying vec4 f_id;
 void main() {
   if (outOfRange(clipBounds[0], clipBounds[1], position)) {
 
-    gl_Position = vec4(0,0,0,0);
+    gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
   } else {
     gl_Position  = projection * view * model * vec4(position, 1.0);
     gl_PointSize = pointSize;

--- a/lib/point-fragment.glsl
+++ b/lib/point-fragment.glsl
@@ -7,7 +7,7 @@ varying vec4 f_color;
 varying vec2 f_uv;
 
 void main() {
-  vec2 pointR = gl_PointCoord.xy - vec2(0.5,0.5);
+  vec2 pointR = gl_PointCoord.xy - vec2(0.5, 0.5);
   if(dot(pointR, pointR) > 0.25) {
     discard;
   }

--- a/lib/point-vertex.glsl
+++ b/lib/point-vertex.glsl
@@ -16,7 +16,7 @@ varying vec2 f_uv;
 void main() {
   if (outOfRange(clipBounds[0], clipBounds[1], position)) {
 
-    gl_Position = vec4(0,0,0,0);
+    gl_Position = vec4(0.0, 0.0 ,0.0 ,0.0);
   } else {
     gl_Position = projection * view * model * vec4(position, 1.0);
   }

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -23,7 +23,9 @@ varying vec4 f_color;
 varying vec2 f_uv;
 
 void main() {
-  if (outOfRange(clipBounds[0], clipBounds[1], f_data)) discard;
+  if (f_color.a == 0.0 ||
+    outOfRange(clipBounds[0], clipBounds[1], f_data)
+  ) discard;
 
   vec3 N = normalize(f_normal);
   vec3 L = normalize(f_lightDirection);

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -12,8 +12,7 @@ uniform float roughness
             , fresnel
             , kambient
             , kdiffuse
-            , kspecular
-            , opacity;
+            , kspecular;
 uniform sampler2D texture;
 
 varying vec3 f_normal
@@ -39,8 +38,8 @@ void main() {
 
   float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);
 
-  vec4 surfaceColor = f_color * texture2D(texture, f_uv);
+  vec4 surfaceColor = vec4(f_color.rgb, 1.0) * texture2D(texture, f_uv);
   vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);
 
-  gl_FragColor = litColor * opacity;
+  gl_FragColor = litColor * f_color.a;
 }

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -30,7 +30,7 @@ void main() {
   cameraCoordinate.xyz /= cameraCoordinate.w;
   f_lightDirection = lightPosition - cameraCoordinate.xyz;
   f_eyeDirection   = eyePosition - cameraCoordinate.xyz;
-  f_normal  = normalize((vec4(normal,0) * inverseModel).xyz);
+  f_normal  = normalize((vec4(normal, 0.0) * inverseModel).xyz);
 
   f_color          = color;
   f_data           = position;

--- a/mesh.js
+++ b/mesh.js
@@ -150,7 +150,7 @@ function getOpacityFromScale(ratio, opacityscale) {
   if(!opacityscale.length) return 1
 
   for(var i = 0; i < opacityscale.length; ++i) {
-    if(opacityscale.length !== 2) return 1
+    if(opacityscale.length < 2) return 1
     if(opacityscale[i][0] === ratio) return opacityscale[i][1]
     if(opacityscale[i][0] > ratio && i > 0) {
       var d = (opacityscale[i][0] - ratio) / (opacityscale[i][0] - opacityscale[i - 1][0])

--- a/mesh.js
+++ b/mesh.js
@@ -144,23 +144,21 @@ proto.setPickBase = function(id) {
   this.pickId = id
 }
 
-function mapOpacity(ratio, opacityscale) {
+function getOpacityFromScale(ratio, opacityscale) {
 
-  if(!opacityscale) return 1; // quick return;
+  if(!opacityscale) return 1
+  if(!opacityscale.length) return 1
 
-  var r = 1 // default: 'uniform'
-
-  if(opacityscale === 'extremes') {
-    r = 1 - Math.sin(ratio * Math.PI)
-  } else if(opacityscale === 'center') {
-    r = 1 - Math.cos(ratio * Math.PI)
-  } else if(opacityscale === 'min') {
-    r = 1 - ratio
-  } else if(opacityscale === 'max') {
-    r = ratio
+  for(var i = 0; i < opacityscale.length; ++i) {
+    if(opacityscale.length !== 2) return 1
+    if(opacityscale[i][0] === ratio) return opacityscale[i][1]
+    if(opacityscale[i][0] > ratio && i > 0) {
+      var d = (opacityscale[i][0] - ratio) / (opacityscale[i][0] - opacityscale[i - 1][0])
+      return opacityscale[i][1] * (1 - d) + d * opacityscale[i - 1][1]
+    }
   }
 
-  return 0.2 + 0.8 * r;
+  return 1
 }
 
 function genColormap(param, opacityscale) {
@@ -179,7 +177,7 @@ function genColormap(param, opacityscale) {
     if(!opacityscale) {
       result[4*i+3] = 255 * c[3]
     } else {
-      result[4*i+3] = 255 * mapOpacity(i / 255.0, opacityscale)
+      result[4*i+3] = 255 * getOpacityFromScale(i / 255.0, opacityscale)
     }
   }
 
@@ -434,7 +432,7 @@ fill_loop:
         }
         if(this.opacityscale && vertexIntensity) {
           tCol.push(c[0], c[1], c[2],
-            this.opacity * mapOpacity(
+            this.opacity * getOpacityFromScale(
               (vertexIntensity[v] - intensityLo) / (intensityHi - intensityLo),
               this.opacityscale
             )
@@ -505,7 +503,7 @@ fill_loop:
           }
           if(this.opacityscale && vertexIntensity) {
             tCol.push(c[0], c[1], c[2],
-              this.opacity * mapOpacity(
+              this.opacity * getOpacityFromScale(
                 (vertexIntensity[v] - intensityLo) / (intensityHi - intensityLo),
                 this.opacityscale
               )
@@ -570,7 +568,7 @@ fill_loop:
 
           if(this.opacityscale && vertexIntensity) {
             tCol.push(c[0], c[1], c[2],
-              this.opacity * mapOpacity(
+              this.opacity * getOpacityFromScale(
                 (vertexIntensity[v] - intensityLo) / (intensityHi - intensityLo),
                 this.opacityscale
               )


### PR DESCRIPTION
Implementation of `opacityscale` useful with volume rendering also in scenarios where different opacity values may needed to be applied depending on `colorscale`.
Please refer to Plotly PR https://github.com/plotly/plotly.js/pull/3488 for more info.
@etpinard 
