### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/lib/contour-vertex.glsl
+++ b/lib/contour-vertex.glsl
@@ -5,5 +5,5 @@ attribute vec3 position;
 uniform mat4 model, view, projection;
 
 void main() {
-  gl_Position = projection * view * model * vec4(position, 1.0);
+  gl_Position = projection * (view * (model * vec4(position, 1.0)));
 }

--- a/lib/edge-vertex.glsl
+++ b/lib/edge-vertex.glsl
@@ -11,7 +11,7 @@ varying vec3 f_data;
 varying vec2 f_uv;
 
 void main() {
-  gl_Position = projection * view * model * vec4(position, 1.0);
+  gl_Position = projection * (view * (model * vec4(position, 1.0)));
   f_color = color;
   f_data  = position;
   f_uv    = uv;

--- a/lib/pick-point-vertex.glsl
+++ b/lib/pick-point-vertex.glsl
@@ -17,7 +17,7 @@ void main() {
 
     gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
   } else {
-    gl_Position  = projection * view * model * vec4(position, 1.0);
+    gl_Position  = projection * (view * (model * vec4(position, 1.0)));
     gl_PointSize = pointSize;
   }
   f_id         = id;

--- a/lib/pick-vertex.glsl
+++ b/lib/pick-vertex.glsl
@@ -9,7 +9,7 @@ varying vec3 f_position;
 varying vec4 f_id;
 
 void main() {
-  gl_Position = projection * view * model * vec4(position, 1.0);
+  gl_Position = projection * (view * (model * vec4(position, 1.0)));
   f_id        = id;
   f_position  = position;
 }

--- a/lib/point-vertex.glsl
+++ b/lib/point-vertex.glsl
@@ -18,7 +18,7 @@ void main() {
 
     gl_Position = vec4(0.0, 0.0 ,0.0 ,0.0);
   } else {
-    gl_Position = projection * view * model * vec4(position, 1.0);
+    gl_Position = projection * (view * (model * vec4(position, 1.0)));
   }
   gl_PointSize = pointSize;
   f_color = color;

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -19,7 +19,7 @@ varying vec4 f_color;
 varying vec2 f_uv;
 
 vec4 project(vec3 p) {
-  return projection * view * model * vec4(p, 1.0);
+  return projection * (view * (model * vec4(p, 1.0)));
 }
 
 void main() {


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23